### PR TITLE
capturing the training set in a closure to avoid retraining for each …

### DIFF
--- a/MachineLearningInAction/MachineLearningInAction/NaiveBayes.fs
+++ b/MachineLearningInAction/MachineLearningInAction/NaiveBayes.fs
@@ -101,6 +101,7 @@ module NaiveBayes =
             label, 
             prop(total, size), 
             Map.map (fun token count -> prop(count, totTokens)) tokenCount)
+        |> Seq.toList
 
     // Classifier function:
     // the classifier is trained on the dataset,
@@ -112,16 +113,17 @@ module NaiveBayes =
     // and returning the highest scoring label.
     // Probabilities are log-transformed to avoid underflow.
     // See "Chapter4.fsx" for an illustration.
-    let classifier frequency dataset words text =
+    let classifier frequency dataset words =
         let estimator = train frequency dataset words
-        let tokenized = vocabulary text
-        estimator
-        |> Seq.map (fun (label, proba, tokens) ->
-            label,
-            tokens
-            |> Map.fold (fun p token value -> 
-                if Set.exists (fun w -> w = token) tokenized 
-                then p + log(value) 
-                else p) (log proba))
-        |> Seq.maxBy snd
-        |> fst
+        fun text ->
+            let tokenized = vocabulary text
+            estimator
+            |> Seq.map (fun (label, proba, tokens) ->
+                label,
+                tokens
+                |> Map.fold (fun p token value -> 
+                    if Set.exists (fun w -> w = token) tokenized 
+                    then p + log(value) 
+                    else p) (log proba))
+            |> Seq.maxBy snd
+            |> fst


### PR DESCRIPTION
I know that it's been a while since you updated this repo, but It's helped me so much to grasp ML concepts that I had to contribute back.
In my experiments with the Bayes clasificator I noticed very fast training times, but extremely slow clasification times. As it turned out due to the lazy Seq evaluation I was retraining the whole model for each entry from my test set.
This can be avoided by capturing the model in a closure.

Many Thanks for this great code!